### PR TITLE
Fix h3 header font

### DIFF
--- a/app/assets/stylesheets/_apprentice.scss
+++ b/app/assets/stylesheets/_apprentice.scss
@@ -61,7 +61,7 @@
   #page-header {
     h3 {
       color: #636363;
-      font: 600 18px/24px proxima-nova,"helvetica neue",arial,sans-serif
+      font: 600 18px/24px $header;
     }
   }
 }


### PR DESCRIPTION
The font family wasn't using Proxima Nova correctly; this updates the stylesheet to use the $header variable, ensuring the font is correct.

Before:
![apprenticeio before](https://f.cloud.github.com/assets/1574/1837443/0f1708ee-742f-11e3-9d55-6c52c7fb72dc.png)

After:
![apprenticeio after](https://f.cloud.github.com/assets/1574/1837442/0f086d84-742f-11e3-9778-f2fb8e9650c7.png)
