### PR TITLE
Update Metis design URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
   end
 
   def metis_design_url
-    "http://www.thisismetis.com/product-design#{utm_parameters}"
+    "http://www.thisismetis.com/ux-front-end-development#{utm_parameters}"
   end
 
   def utm_parameters


### PR DESCRIPTION
The url for the design bootcamp has changed and their redirect takes out the query string we're trying to pass from apprentice.io. Updating the url so it doesn't have to redirect and it preserves the parameters.
