### PR TITLE
Prepare apprentice.io for Heroku deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,13 @@
 source "https://rubygems.org"
 
+ruby "2.1.3"
+
 gem "bitters"
 gem "bourbon"
 gem "neat"
 gem "middleman", "~> 3.3.6"
 gem "rack-contrib"
+gem "rake"
 
 group :development do
   gem "middleman-livereload"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rake (10.3.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -141,3 +142,4 @@ DEPENDENCIES
   middleman-livereload
   neat
   rack-contrib
+  rake

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec middleman server

--- a/config.ru
+++ b/config.ru
@@ -1,24 +1,32 @@
-require 'rubygems'
-require 'middleman/rack'
-require 'rack/contrib/try_static'
+$:.unshift File.dirname(__FILE__)
 
-run Middleman.server
+require "rack/contrib/try_static"
+
+ONE_WEEK = 604_800
+FIVE_MINUTES = 300
 
 use Rack::Deflater
 use Rack::TryStatic,
-  root: 'tmp',
+  root: "tmp",
   urls: %w[/],
-  try: %w[.html index.html /index.html]
-
-FIVE_MINUTES=300
+  try: %w[.html index.html /index.html],
+  header_rules: [
+    [
+      %w(css js png jpg woff),
+      { "Cache-Control" => "public, max-age=#{ONE_WEEK}" }
+    ],
+    [
+      %w(html), { "Cache-Control" => "public, max-age=#{FIVE_MINUTES}" }
+    ]
+  ]
 
 run lambda { |env|
   [
     404,
     {
-      'Content-Type'  => 'text/html',
-      'Cache-Control' => "public, max-age=#{FIVE_MINUTES}"
+      "Content-Type"  => "text/html",
+      "Cache-Control" => "public, max-age=#{FIVE_MINUTES}"
     },
-    ['File not found']
+    ["File not found"]
   ]
 }


### PR DESCRIPTION
- Specify a Ruby version.
- Include `rake` gem.
- Delete `Procfile`.
  Rely on Heroku's default webserver for Ruby processes (Webrick),
  which will read from `config.ru`.
- Cache static files with a long TTL.
