### PR TITLE
Update weekly pay

### DIFF
--- a/source/partials/_faq.html.erb
+++ b/source/partials/_faq.html.erb
@@ -25,8 +25,8 @@
       paid employees?
     </dt>
     <dd>
-      Apprentices are paid, W2, employees of thoughtbot. The current pay is
-      $500/week and includes health insurance and other benefits.
+      Apprentices are paid, W2, employees of thoughtbot. The position
+      includes health insurance and other benefits.
     </dd>
 
     <dt>


### PR DESCRIPTION
$500/week is $2,000/month,
which is pretty hard to get by on in the Bay Area:

https://www.rentjungle.com/average-rent-in-oakland-rent-trends/

Thoughts on doubling it?
Or, not listing it on the website to let it flex per-location?